### PR TITLE
Return LagMatrix containing metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Changed functions operating on slices to return a `LagMatrix` struct
+  providing meta information about the generated matrix.
+
 ## [0.3.0] - 2023-09-02
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ mod ndarray_support;
 
 use std::borrow::Borrow;
 use std::fmt::{Display, Formatter};
+use std::ops::Deref;
 
 #[cfg(feature = "ndarray")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ndarray")))]
@@ -124,6 +125,85 @@ pub mod prelude {
     #[cfg(feature = "ndarray")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ndarray")))]
     pub use crate::ndarray_support::LagMatrixFromArray;
+}
+
+/// A matrix of time-lagged values.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct LagMatrix<T> {
+    data: Vec<T>,
+    num_rows: usize,
+    num_cols: usize,
+    series_length: usize,
+    series_count: usize,
+    num_lags: usize,
+    row_stride: usize,
+    row_major: bool,
+}
+
+impl<T> LagMatrix<T> {
+    /// The number of logical rows in the matrix.
+    /// This value is less than or equal to [`row_stride`].
+    ///
+    /// Note that the physical row length, i.e. the number of elements
+    /// to skip in order to go the next row, is determined by by the [`row_stride`].
+    pub fn num_rows(&self) -> usize {
+        self.num_rows
+    }
+
+    /// The number of columns in the matrix.
+    pub fn num_cols(&self) -> usize {
+        self.num_cols
+    }
+
+    /// The number of time series captured by the matrix.
+    pub fn series_count(&self) -> usize {
+        self.series_count
+    }
+
+    /// The length of each time series captured by the matrix.
+    pub fn series_length(&self) -> usize {
+        self.series_length
+    }
+
+    /// The number of lags represented in the matrix.
+    pub fn num_lags(&self) -> usize {
+        self.num_lags
+    }
+
+    /// The number of elements to skip in order to go from one
+    /// row to another. This value is greater than or equal to [`num_rows`].
+    pub fn row_stride(&self) -> usize {
+        self.row_stride
+    }
+
+    /// Determines whether the matrix is row-major, i.e. time series data
+    /// lies along the columns and lags are produced along the columns.
+    pub fn is_row_major(&self) -> bool {
+        self.row_major
+    }
+
+    /// Determines whether the matrix is column-major, i.e. time series data
+    /// lies along the columns and lags are produced along the rows.
+    pub fn is_column_major(&self) -> bool {
+        !self.row_major
+    }
+
+    /// Obtains the matrix layout.
+    pub fn matrix_layout(&self) -> MatrixLayout {
+        if self.row_major {
+            MatrixLayout::RowMajor(self.series_length)
+        } else {
+            MatrixLayout::ColumnMajor(self.series_length)
+        }
+    }
+}
+
+impl<T> Deref for LagMatrix<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
 }
 
 /// Provides the [`lag_matrix`](CreateLagMatrix::lag_matrix) and [`lag_matrix_2d`](CreateLagMatrix::lag_matrix_2d)
@@ -174,7 +254,7 @@ pub trait CreateLagMatrix<T> {
     ///     ]
     /// );
     /// ```
-    fn lag_matrix(&self, lags: usize, fill: T, stride: usize) -> Result<Vec<T>, LagError>;
+    fn lag_matrix(&self, lags: usize, fill: T, stride: usize) -> Result<LagMatrix<T>, LagError>;
 
     /// Create a time-lagged matrix of multiple time series.
     ///
@@ -277,7 +357,7 @@ pub trait CreateLagMatrix<T> {
         lags: usize,
         fill: T,
         row_stride: usize,
-    ) -> Result<Vec<T>, LagError>;
+    ) -> Result<LagMatrix<T>, LagError>;
 }
 
 impl<S, T> CreateLagMatrix<T> for S
@@ -286,7 +366,7 @@ where
     T: Copy,
 {
     #[inline(always)]
-    fn lag_matrix(&self, lags: usize, fill: T, stride: usize) -> Result<Vec<T>, LagError> {
+    fn lag_matrix(&self, lags: usize, fill: T, stride: usize) -> Result<LagMatrix<T>, LagError> {
         lag_matrix(self.borrow(), lags, fill, stride)
     }
 
@@ -297,7 +377,7 @@ where
         lags: usize,
         fill: T,
         row_stride: usize,
-    ) -> Result<Vec<T>, LagError> {
+    ) -> Result<LagMatrix<T>, LagError> {
         lag_matrix_2d(self.borrow(), layout, lags, fill, row_stride)
     }
 }
@@ -352,9 +432,13 @@ pub fn lag_matrix<T: Copy>(
     lags: usize,
     fill: T,
     mut stride: usize,
-) -> Result<Vec<T>, LagError> {
-    if lags == 0 || data.is_empty() {
-        return Ok(data.to_vec());
+) -> Result<LagMatrix<T>, LagError> {
+    if lags == 0 {
+        return Err(LagError::InvalidLags);
+    }
+
+    if data.is_empty() {
+        return Err(LagError::EmptyData);
     }
 
     let data_rows = data.len();
@@ -373,17 +457,31 @@ pub fn lag_matrix<T: Copy>(
     let mut lagged = vec![fill; stride * (lags + 1)];
     lagged[..data.len()].copy_from_slice(data);
 
+    let mut num_lags = 0;
     for lag in 1..=lags {
+        num_lags += 1;
         let lagged_offset = lag * stride + lag;
         let lagged_rows = data_rows - lag;
         let lagged_end = lagged_offset + lagged_rows;
         lagged[lagged_offset..lagged_end].copy_from_slice(&data[0..lagged_rows]);
     }
 
-    Ok(lagged)
+    let matrix = LagMatrix {
+        data: lagged,
+        num_rows: data_rows,
+        num_cols: num_lags + 1,
+        series_length: data_rows,
+        row_stride: stride,
+        series_count: 1,
+        num_lags: num_lags + 1, // including zero lag
+        row_major: true,
+    };
+
+    Ok(matrix)
 }
 
 /// Describes the layout of the data matrix.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub enum MatrixLayout {
     /// Data is laid out row-wise, i.e. reach row of the matrix contains a time series
     /// and the columns represent points in time.
@@ -508,9 +606,13 @@ pub fn lag_matrix_2d<T: Copy>(
     lags: usize,
     fill: T,
     mut row_stride: usize,
-) -> Result<Vec<T>, LagError> {
-    if lags == 0 || data_matrix.is_empty() {
-        return Ok(data_matrix.to_vec());
+) -> Result<LagMatrix<T>, LagError> {
+    if lags == 0 {
+        return Err(LagError::InvalidLags);
+    }
+
+    if data_matrix.is_empty() {
+        return Err(LagError::EmptyData);
     }
 
     let series_length = layout.len();
@@ -547,7 +649,17 @@ pub fn lag_matrix_2d<T: Copy>(
                         .copy_from_slice(&data_matrix[data_start..data_end]);
                 }
             }
-            lagged
+
+            LagMatrix {
+                data: lagged,
+                num_rows: series_length,
+                num_cols: num_series * (lags + 1),
+                series_length,
+                series_count: num_series,
+                num_lags: lags + 1, // including zero-lag
+                row_stride,
+                row_major: true,
+            }
         }
         MatrixLayout::ColumnMajor(_) => {
             if row_stride < num_series * lags {
@@ -581,7 +693,16 @@ pub fn lag_matrix_2d<T: Copy>(
                 lagged.copy_within(data_start..data_end, lagged_offset);
             }
 
-            lagged
+            LagMatrix {
+                data: lagged,
+                num_cols: num_series * (lags + 1),
+                num_rows: series_length,
+                series_length,
+                series_count: num_series,
+                num_lags: lags + 1, // including zero-lag
+                row_stride,
+                row_major: false,
+            }
         }
     })
 }
@@ -589,6 +710,10 @@ pub fn lag_matrix_2d<T: Copy>(
 /// An error during creation of a lagged data matrix.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum LagError {
+    /// Invalid or no lags were specified.
+    InvalidLags,
+    /// The data slice was empty.
+    EmptyData,
     /// The number of lags is greater than the number of data points.
     LagExceedsValueCount,
     /// The row/column stride is less than the number of elements.
@@ -624,6 +749,8 @@ impl Display for LagError {
                 f,
                 "The data is in an invalid (e.g. non-contiguous) memory layout"
             ),
+            LagError::InvalidLags => write!(f, "Invalid or no lags were specified"),
+            LagError::EmptyData => write!(f, "TThe data slice was emptyt"),
         }
     }
 }
@@ -641,8 +768,17 @@ mod tests {
         let direct = lag_matrix(&data, 3, lag, 0).unwrap();
         let implicit = data.lag_matrix(3, lag, 0).unwrap();
 
+        assert_eq!(direct.num_lags(), 4);
+        assert_eq!(direct.num_rows(), 4);
+        assert_eq!(direct.num_cols(), 4);
+        assert_eq!(direct.row_stride(), 4);
+        assert_eq!(direct.series_count(), 1);
+        assert_eq!(direct.series_length(), 4);
+        assert_eq!(direct.matrix_layout(), MatrixLayout::RowMajor(4));
+        assert!(direct.is_row_major());
+
         assert_eq!(
-            direct,
+            direct.as_ref(),
             &[
                 42.0, 40.0, 38.0, 36.0, // original data
                  lag, 42.0, 40.0, 38.0, // first lag
@@ -662,8 +798,17 @@ mod tests {
 
         let direct = lag_matrix(&data, 3, lag, 5).unwrap();
 
+        assert_eq!(direct.num_lags(), 4);
+        assert_eq!(direct.num_rows(), 4);
+        assert_eq!(direct.num_cols(), 4);
+        assert_eq!(direct.row_stride(), 5);
+        assert_eq!(direct.series_count(), 1);
+        assert_eq!(direct.series_length(), 4);
+        assert_eq!(direct.matrix_layout(), MatrixLayout::RowMajor(4));
+        assert!(direct.is_row_major());
+
         assert_eq!(
-            direct,
+            direct.as_ref(),
             &[
                 42.0, 40.0, 38.0, 36.0, padding, // original data
                  lag, 42.0, 40.0, 38.0, padding, // first lag
@@ -682,8 +827,17 @@ mod tests {
 
         let direct = lag_matrix(&data, 3, lag, 8).unwrap();
 
+        assert_eq!(direct.num_lags(), 4);
+        assert_eq!(direct.num_rows(), 4);
+        assert_eq!(direct.num_cols(), 4);
+        assert_eq!(direct.row_stride(), 8);
+        assert_eq!(direct.series_count(), 1);
+        assert_eq!(direct.series_length(), 4);
+        assert_eq!(direct.matrix_layout(), MatrixLayout::RowMajor(4));
+        assert!(direct.is_row_major());
+
         assert_eq!(
-            direct,
+            direct.as_ref(),
             &[
                 42.0, 40.0, 38.0, 36.0, padding, padding, padding, padding, // original data
                  lag, 42.0, 40.0, 38.0, padding, padding, padding, padding, // first lag
@@ -707,8 +861,17 @@ mod tests {
 
         let direct = lag_matrix_2d(&data, MatrixLayout::RowMajor(4), 3, lag, 5).unwrap();
 
+        assert_eq!(direct.num_lags(), 4);
+        assert_eq!(direct.num_rows(), 4);
+        assert_eq!(direct.num_cols(), 8);
+        assert_eq!(direct.row_stride(), 5);
+        assert_eq!(direct.series_count(), 2);
+        assert_eq!(direct.series_length(), 4);
+        assert_eq!(direct.matrix_layout(), MatrixLayout::RowMajor(4));
+        assert!(direct.is_row_major());
+
         assert_eq!(
-            direct,
+            direct.as_ref(),
             &[
                  1.0,  2.0,  3.0,  4.0, padding, // original data
                 -1.0, -2.0, -3.0, -4.0, padding,
@@ -738,8 +901,17 @@ mod tests {
 
         let direct = lag_matrix_2d(&data, MatrixLayout::ColumnMajor(4), 3, lag, 9).unwrap();
 
+        assert_eq!(direct.num_lags(), 4);
+        assert_eq!(direct.num_rows(), 4);
+        assert_eq!(direct.num_cols(), 8);
+        assert_eq!(direct.row_stride(), 9);
+        assert_eq!(direct.series_count(), 2);
+        assert_eq!(direct.series_length(), 4);
+        assert_eq!(direct.matrix_layout(), MatrixLayout::ColumnMajor(4));
+        assert!(!direct.is_row_major());
+
         assert_eq!(
-            direct,
+            direct.as_ref(),
             &[
             //   original
             //   |-----|    first lag

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,17 @@ impl<T> LagMatrix<T> {
             MatrixLayout::ColumnMajor(self.series_length)
         }
     }
+
+    /// Converts this [`LagMatrix`] into a vector.
+    pub fn into_vec(self) -> Vec<T> {
+        self.data
+    }
+}
+
+impl<T> Into<Vec<T>> for LagMatrix<T> {
+    fn into(self) -> Vec<T> {
+        self.data
+    }
 }
 
 impl<T> Deref for LagMatrix<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,50 +146,58 @@ impl<T> LagMatrix<T> {
     ///
     /// Note that the physical row length, i.e. the number of elements
     /// to skip in order to go the next row, is determined by by the [`row_stride`].
-    pub fn num_rows(&self) -> usize {
+    #[inline(always)]
+    pub const fn num_rows(&self) -> usize {
         self.num_rows
     }
 
     /// The number of columns in the matrix.
-    pub fn num_cols(&self) -> usize {
+    #[inline(always)]
+    pub const fn num_cols(&self) -> usize {
         self.num_cols
     }
 
     /// The number of time series captured by the matrix.
-    pub fn series_count(&self) -> usize {
+    #[inline(always)]
+    pub const fn series_count(&self) -> usize {
         self.series_count
     }
 
     /// The length of each time series captured by the matrix.
-    pub fn series_length(&self) -> usize {
+    #[inline(always)]
+    pub const fn series_length(&self) -> usize {
         self.series_length
     }
 
     /// The number of lags represented in the matrix.
-    pub fn num_lags(&self) -> usize {
+    #[inline(always)]
+    pub const fn num_lags(&self) -> usize {
         self.num_lags
     }
 
     /// The number of elements to skip in order to go from one
     /// row to another. This value is greater than or equal to [`num_rows`].
-    pub fn row_stride(&self) -> usize {
+    #[inline(always)]
+    pub const fn row_stride(&self) -> usize {
         self.row_stride
     }
 
     /// Determines whether the matrix is row-major, i.e. time series data
     /// lies along the columns and lags are produced along the columns.
-    pub fn is_row_major(&self) -> bool {
+    #[inline(always)]
+    pub const fn is_row_major(&self) -> bool {
         self.row_major
     }
 
     /// Determines whether the matrix is column-major, i.e. time series data
     /// lies along the columns and lags are produced along the rows.
-    pub fn is_column_major(&self) -> bool {
+    #[inline(always)]
+    pub const fn is_column_major(&self) -> bool {
         !self.row_major
     }
 
     /// Obtains the matrix layout.
-    pub fn matrix_layout(&self) -> MatrixLayout {
+    pub const fn matrix_layout(&self) -> MatrixLayout {
         if self.row_major {
             MatrixLayout::RowMajor(self.series_length)
         } else {
@@ -198,12 +206,14 @@ impl<T> LagMatrix<T> {
     }
 
     /// Converts this [`LagMatrix`] into a vector.
+    #[inline(always)]
     pub fn into_vec(self) -> Vec<T> {
         self.data
     }
 }
 
 impl<T> Into<Vec<T>> for LagMatrix<T> {
+    #[inline(always)]
     fn into(self) -> Vec<T> {
         self.data
     }
@@ -212,8 +222,29 @@ impl<T> Into<Vec<T>> for LagMatrix<T> {
 impl<T> Deref for LagMatrix<T> {
     type Target = [T];
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         &self.data
+    }
+}
+
+impl<T> PartialEq<[T]> for LagMatrix<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &[T]) -> bool {
+        self.data.iter().eq(other)
+    }
+}
+
+impl<S, T> PartialEq<S> for LagMatrix<T>
+where
+    S: AsRef<[T]>,
+    T: PartialEq,
+{
+    #[inline(always)]
+    fn eq(&self, other: &S) -> bool {
+        self.data.eq(other.as_ref())
     }
 }
 
@@ -789,7 +820,7 @@ mod tests {
         assert!(direct.is_row_major());
 
         assert_eq!(
-            direct.as_ref(),
+            direct,
             &[
                 42.0, 40.0, 38.0, 36.0, // original data
                  lag, 42.0, 40.0, 38.0, // first lag
@@ -819,7 +850,7 @@ mod tests {
         assert!(direct.is_row_major());
 
         assert_eq!(
-            direct.as_ref(),
+            direct,
             &[
                 42.0, 40.0, 38.0, 36.0, padding, // original data
                  lag, 42.0, 40.0, 38.0, padding, // first lag
@@ -848,7 +879,7 @@ mod tests {
         assert!(direct.is_row_major());
 
         assert_eq!(
-            direct.as_ref(),
+            direct,
             &[
                 42.0, 40.0, 38.0, 36.0, padding, padding, padding, padding, // original data
                  lag, 42.0, 40.0, 38.0, padding, padding, padding, padding, // first lag
@@ -882,7 +913,7 @@ mod tests {
         assert!(direct.is_row_major());
 
         assert_eq!(
-            direct.as_ref(),
+            direct,
             &[
                  1.0,  2.0,  3.0,  4.0, padding, // original data
                 -1.0, -2.0, -3.0, -4.0, padding,
@@ -922,7 +953,7 @@ mod tests {
         assert!(!direct.is_row_major());
 
         assert_eq!(
-            direct.as_ref(),
+            direct,
             &[
             //   original
             //   |-----|    first lag

--- a/src/ndarray_support.rs
+++ b/src/ndarray_support.rs
@@ -64,7 +64,9 @@ where
             let lagged = lag_matrix(slice, lags, fill, stride)?;
             let series_len = slice.len();
             let actual_stride = lagged.len() / series_len;
-            Ok(make_array(lags, lagged, series_len, actual_stride))
+
+            // TODO: Refactor to use &LagMatrix<A> directly
+            Ok(make_array(lags, lagged.data, series_len, actual_stride))
         } else {
             Err(LagError::InvalidMemoryLayout)
         }
@@ -88,10 +90,11 @@ where
                     stride,
                 )?;
 
+                // TODO: Refactor to use &LagMatrix<A> directly
                 let actual_stride = stride.max(series_len);
                 Ok(make_array_2d_row_major(
                     lags,
-                    lagged,
+                    lagged.data,
                     series_len,
                     num_series,
                     actual_stride,
@@ -107,10 +110,11 @@ where
                     stride,
                 )?;
 
+                // TODO: Refactor to use &LagMatrix<A> directly
                 let actual_stride = stride.max(series_len);
                 Ok(make_array_2d_column_major(
                     lags,
-                    lagged,
+                    lagged.data,
                     series_len,
                     num_series,
                     actual_stride,

--- a/src/ndarray_support.rs
+++ b/src/ndarray_support.rs
@@ -1,4 +1,4 @@
-use crate::{lag_matrix, lag_matrix_2d, LagError, MatrixLayout};
+use crate::{lag_matrix, lag_matrix_2d, LagError, LagMatrix, MatrixLayout};
 use ndarray::prelude::*;
 use ndarray::{Array1, OwnedRepr};
 
@@ -62,11 +62,7 @@ where
     fn lag_matrix(&self, lags: usize, fill: A, stride: usize) -> Result<Array2<A>, LagError> {
         if let Some(slice) = self.as_slice() {
             let lagged = lag_matrix(slice, lags, fill, stride)?;
-            let series_len = slice.len();
-            let actual_stride = lagged.len() / series_len;
-
-            // TODO: Refactor to use &LagMatrix<A> directly
-            Ok(make_array(lags, lagged.data, series_len, actual_stride))
+            Ok(make_array(lagged))
         } else {
             Err(LagError::InvalidMemoryLayout)
         }
@@ -81,7 +77,6 @@ where
         if let Some(slice) = self.as_slice_memory_order() {
             if self.is_standard_layout() {
                 let series_len = self.ncols();
-                let num_series = self.nrows();
                 let lagged = lag_matrix_2d(
                     slice,
                     MatrixLayout::RowMajor(series_len),
@@ -90,18 +85,9 @@ where
                     stride,
                 )?;
 
-                // TODO: Refactor to use &LagMatrix<A> directly
-                let actual_stride = stride.max(series_len);
-                Ok(make_array_2d_row_major(
-                    lags,
-                    lagged.data,
-                    series_len,
-                    num_series,
-                    actual_stride,
-                ))
+                Ok(make_array_2d_row_major(lagged))
             } else {
                 let series_len = self.nrows();
-                let num_series = self.ncols();
                 let lagged = lag_matrix_2d(
                     slice,
                     MatrixLayout::ColumnMajor(series_len),
@@ -110,15 +96,7 @@ where
                     stride,
                 )?;
 
-                // TODO: Refactor to use &LagMatrix<A> directly
-                let actual_stride = stride.max(series_len);
-                Ok(make_array_2d_column_major(
-                    lags,
-                    lagged.data,
-                    series_len,
-                    num_series,
-                    actual_stride,
-                ))
+                Ok(make_array_2d_column_major(lagged))
             }
         } else {
             Err(LagError::InvalidMemoryLayout)
@@ -126,56 +104,51 @@ where
     }
 }
 
-fn make_array<A>(
-    lags: usize,
-    lagged: Vec<A>,
-    series_len: usize,
-    actual_stride: usize,
-) -> ArrayBase<OwnedRepr<A>, Ix2> {
-    let array = if actual_stride == series_len {
-        Array2::<A>::from_shape_vec((series_len, lags + 1), lagged).expect("the shape is valid")
-    } else {
-        Array2::<A>::from_shape_vec((series_len, lags + 1).strides((actual_stride, 1)), lagged)
-            .expect("the shape is valid")
-    };
-    array
-}
-
-fn make_array_2d_row_major<A>(
-    lags: usize,
-    lagged: Vec<A>,
-    series_len: usize,
-    series_count: usize,
-    actual_stride: usize,
-) -> ArrayBase<OwnedRepr<A>, Ix2> {
-    let array = if actual_stride == series_len {
-        Array2::<A>::from_shape_vec((series_len, series_count * (lags + 1)), lagged)
+fn make_array<A>(matrix: LagMatrix<A>) -> ArrayBase<OwnedRepr<A>, Ix2> {
+    let array = if matrix.row_stride == matrix.series_length {
+        Array2::<A>::from_shape_vec((matrix.series_length, matrix.num_lags), matrix.data)
             .expect("the shape is valid")
     } else {
         Array2::<A>::from_shape_vec(
-            (series_count * (lags + 1), series_len).strides((actual_stride, 1)),
-            lagged,
+            (matrix.series_length, matrix.num_lags).strides((matrix.row_stride, 1)),
+            matrix.data,
         )
         .expect("the shape is valid")
     };
     array
 }
 
-fn make_array_2d_column_major<A>(
-    lags: usize,
-    lagged: Vec<A>,
-    series_len: usize,
-    series_count: usize,
-    actual_stride: usize,
-) -> ArrayBase<OwnedRepr<A>, Ix2> {
-    let array = if actual_stride == series_len {
-        Array2::<A>::from_shape_vec((series_count * (lags + 1), series_len), lagged)
-            .expect("the shape is valid")
-            .reversed_axes()
+fn make_array_2d_row_major<A>(matrix: LagMatrix<A>) -> ArrayBase<OwnedRepr<A>, Ix2> {
+    let array = if matrix.row_stride == matrix.series_length {
+        Array2::<A>::from_shape_vec(
+            (matrix.series_length, matrix.series_count * matrix.num_lags),
+            matrix.into_vec(),
+        )
+        .expect("the shape is valid")
     } else {
         Array2::<A>::from_shape_vec(
-            (series_count * (lags + 1), series_len).strides((1, actual_stride)),
-            lagged,
+            (matrix.series_count * matrix.num_lags, matrix.series_length)
+                .strides((matrix.row_stride, 1)),
+            matrix.into_vec(),
+        )
+        .expect("the shape is valid")
+    };
+    array
+}
+
+fn make_array_2d_column_major<A>(matrix: LagMatrix<A>) -> ArrayBase<OwnedRepr<A>, Ix2> {
+    let array = if matrix.row_stride == matrix.series_length {
+        Array2::<A>::from_shape_vec(
+            (matrix.series_count * matrix.num_lags, matrix.series_length),
+            matrix.into_vec(),
+        )
+        .expect("the shape is valid")
+        .reversed_axes()
+    } else {
+        Array2::<A>::from_shape_vec(
+            (matrix.series_count * matrix.num_lags, matrix.series_length)
+                .strides((1, matrix.row_stride)),
+            matrix.into_vec(),
         )
         .expect("the shape is valid")
         .reversed_axes()


### PR DESCRIPTION
This PR changes the `lag_matrix` functions to return a `LagMatrix` struct that captures essential matrix information, including row and column count, row strides, time series lengths, lag counts, etc.