### PR TITLE
Allow specification of lags as iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Changed functions operating on slices to return a `LagMatrix` struct
   providing meta information about the generated matrix.
+- Lag indices can now be specified as any `IntoIterator<Item = usize>`, e.g. range, array or slice.
 
 ## [0.3.0] - 2023-09-02
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ fn singular_series() {
     
     // Create three lagged versions.
     // Use a stride of 5 for the rows, i.e. pad with one extra entry.
-    let lagged = lag_matrix(&data, 3, lag, 5).unwrap();
+    let lagged = lag_matrix(&data, 0..=3, lag, 5).unwrap();
+
+    // The function is also available via the CreateLagMatrix.
+    // All methods take an IntoIterator<Item = usize> for the lags.
+    let other = data.lag_matrix([0, 1, 2, 3], lag, 5).unwrap();
     
     assert_eq!(
         lagged,
@@ -33,6 +37,7 @@ fn singular_series() {
             lag, lag, lag, 1.0, padding, // third lag
         ]
     );
+    assert_eq!(lagged, other);
 }
 ```
 


### PR DESCRIPTION
With this change, lags can be specified as any `IntoIterator<Item = usize>`, e.g. as range (`0..=3`), array (`[0, 1, 2, 3]`), slice, etc. This more closely resembles MATLAB's `lagmatrix` API and allows more fine-grained control, such as out of order lags `[3, 1, 2]` or step size specification, e.g. `(0..=100).step_by(10)`.